### PR TITLE
Make GitHub detect *.fex as Forth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.fex linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.fex` files as Forth.

Thanks!
